### PR TITLE
Print message on website scrape error

### DIFF
--- a/src/main/kotlin/org/example/Dictionary.kt
+++ b/src/main/kotlin/org/example/Dictionary.kt
@@ -7,7 +7,7 @@ import it.skrape.fetcher.skrape
 import java.io.File
 
 
-fun textFromWebsite(url: String): String? = try {
+fun textFromWebsite(url: String): String = try {
     skrape(BrowserFetcher) {
         request {
             this.url = url
@@ -17,8 +17,8 @@ fun textFromWebsite(url: String): String? = try {
         }
     }
 } catch (e: Exception) {
-    System.err.println(e.message)
-    null
+    System.err.println("Error while trying to read text from the given website. Message: ${e.message}")
+    ""
 }
 
 

--- a/src/test/kotlin/org/example/DictionaryKtTest.kt
+++ b/src/test/kotlin/org/example/DictionaryKtTest.kt
@@ -163,17 +163,17 @@ class DictionaryKtTest {
     fun `textFromWebsite protocol missing`() {
         val port = ports.next()
         embeddedServer(Netty, port, host = "0.0.0.0", module = Application::exampleCom).start(wait = false)
-        textFromWebsite("localhost:$port/") shouldBe null
+        textFromWebsite("localhost:$port/") shouldBe ""
     }
 
     @Test
     fun `textFromWebsite unknown host`() {
-        textFromWebsite("http://cgtsirenbml8hcduygesrtiyelschtibyesr") shouldBe null
+        textFromWebsite("http://cgtsirenbml8hcduygesrtiyelschtibyesr") shouldBe ""
     }
 
     @Test
     fun `textFromWebsite empty url`() {
-        textFromWebsite("") shouldBe null
+        textFromWebsite("") shouldBe ""
     }
 
     @Test


### PR DESCRIPTION
return an empty string instead of null